### PR TITLE
Create Rust FFI example with zlib

### DIFF
--- a/rust_ffi_example/Cargo.toml
+++ b/rust_ffi_example/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rust_ffi_example"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+libc = "0.2"
+
+[build-dependencies]
+cc = "1.0"
+pkg-config = "0.3"

--- a/rust_ffi_example/build.rs
+++ b/rust_ffi_example/build.rs
@@ -1,0 +1,27 @@
+extern crate cc;
+
+fn main() {
+    // Check if zlib is available on the system
+    match pkg_config::probe_library("zlib") {
+        Ok(_) => {
+            // If zlib is found by pkg-config, it will handle the linking.
+            // We still need to compile our C code.
+            println!("cargo:rerun-if-changed=src/clib.c");
+            cc::Build::new()
+                .file("src/clib.c")
+                .compile("clib");
+            println!("cargo:rustc-link-lib=z"); // Link against zlib
+        }
+        Err(_) => {
+            // Fallback if pkg-config fails or zlib is not found by it.
+            // This assumes zlib headers are in a standard location and zlib is linkable as `libz`.
+            // For more robust builds, especially cross-platform, consider using vcpkg or other methods.
+            println!("cargo:warning=pkg-config failed to find zlib, attempting to link with -lz directly. This might fail if zlib is not in the default search paths.");
+            println!("cargo:rerun-if-changed=src/clib.c");
+            cc::Build::new()
+                .file("src/clib.c")
+                .compile("clib"); // Output will be libclib.a
+            println!("cargo:rustc-link-lib=z"); // Link against zlib
+        }
+    }
+}

--- a/rust_ffi_example/src/clib.c
+++ b/rust_ffi_example/src/clib.c
@@ -1,0 +1,71 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <zlib.h>
+
+// Define a struct to return both buffer and length
+typedef struct {
+    char *buffer;
+    unsigned long length;
+} CompressedData;
+
+// Function to compress a string using zlib
+// The caller is responsible for freeing the returned buffer
+CompressedData compress_string(const char *input, unsigned long input_len) {
+    unsigned long output_len_bound = compressBound(input_len);
+    char *output_buffer = (char *)malloc(output_len_bound);
+    CompressedData result = {NULL, 0};
+
+    if (output_buffer == NULL) {
+        perror("Failed to allocate memory for compression");
+        return result; // Return empty result
+    }
+
+    int res = compress((Bytef *)output_buffer, &output_len_bound, (const Bytef *)input, input_len);
+
+    if (res != Z_OK) {
+        fprintf(stderr, "Compression failed: %d\n", res);
+        free(output_buffer);
+        return result; // Return empty result
+    }
+
+    result.buffer = output_buffer;
+    result.length = output_len_bound;
+    return result;
+}
+
+// Function to free the memory allocated by compress_string
+void free_compressed_data(CompressedData data) {
+    if (data.buffer != NULL) {
+        free(data.buffer);
+    }
+}
+
+#ifdef BUILD_TEST_MAIN
+// Main function for testing the C code directly (optional)
+int main() {
+    const char *test_str = "Hello, world! This is a test string for zlib compression.";
+    unsigned long test_str_len = strlen(test_str);
+
+    printf("Original string: '%s'\n", test_str);
+    printf("Original length: %lu\n", test_str_len);
+
+    CompressedData compressed = compress_string(test_str, test_str_len);
+
+    if (compressed.buffer) {
+        printf("Successfully compressed string.\n");
+        printf("Compressed length: %lu\n", compressed.length);
+        // Optional: print compressed data (might be binary)
+        // printf("Compressed data (hex): ");
+        // for (unsigned long i = 0; i < compressed.length; ++i) {
+        //     printf("%02x", (unsigned char)compressed.buffer[i]);
+        // }
+        // printf("\n");
+        free_compressed_data(compressed);
+    } else {
+        printf("Compression failed.\n");
+    }
+
+    return 0;
+}
+#endif

--- a/rust_ffi_example/src/lib.rs
+++ b/rust_ffi_example/src/lib.rs
@@ -1,0 +1,127 @@
+use std::ffi::CString;
+use std::os::raw::{c_char, c_ulong};
+use std::slice;
+
+// Define the Rust equivalent of the C struct CompressedData
+#[repr(C)]
+pub struct CompressedData {
+    pub buffer: *mut c_char,
+    pub length: c_ulong,
+}
+
+// Declare the C functions that will be called from Rust
+extern "C" {
+    pub fn compress_string(input: *const c_char, input_len: c_ulong) -> CompressedData;
+    pub fn free_compressed_data(data: CompressedData);
+}
+
+/// Compresses a string using the C library's `compress_string` function.
+///
+/// # Arguments
+/// * `s`: The string slice to compress.
+///
+/// # Returns
+/// * `Ok(Vec<u8>)` containing the compressed data if successful.
+/// * `Err(&str)` with an error message if compression fails or input is invalid.
+///
+/// # Safety
+/// This function wraps unsafe FFI calls. It handles C string conversion
+/// and memory management for the data returned by the C function.
+pub fn compress_rust_string(s: &str) -> Result<Vec<u8>, &'static str> {
+    // Convert the Rust string to a C-compatible string (null-terminated)
+    let c_input_string = match CString::new(s) {
+        Ok(cs) => cs,
+        Err(_) => return Err("Failed to create CString, input might contain null bytes"),
+    };
+
+    // Get a pointer to the C string's raw data
+    let input_ptr = c_input_string.as_ptr();
+    // Length of the string (excluding the null terminator for compress_string)
+    let input_len = s.len() as c_ulong;
+
+    // Call the C function
+    // This is an unsafe block because we are calling C code and dealing with raw pointers.
+    let compressed_c_data = unsafe { compress_string(input_ptr, input_len) };
+
+    // Check if the C function returned a valid buffer
+    if compressed_c_data.buffer.is_null() {
+        // The C function should have printed an error, but we also return an error here.
+        // Note: No need to call free_compressed_data if buffer is null.
+        return Err("Compression failed in C library (null buffer returned)");
+    }
+
+    // Convert the C data (raw pointer and length) to a Rust Vec<u8>
+    // This is also unsafe because we are dereferencing a raw pointer from C.
+    let rust_vec: Vec<u8> = unsafe {
+        // Create a slice from the raw parts
+        let slice = slice::from_raw_parts(compressed_c_data.buffer as *const u8, compressed_c_data.length as usize);
+        // Clone the data into a new Vec<u8>
+        slice.to_vec()
+    };
+
+    // Free the memory allocated by the C function
+    // This is crucial to prevent memory leaks.
+    unsafe {
+        free_compressed_data(compressed_c_data);
+    }
+
+    Ok(rust_vec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compression_basic() {
+        let original_data = "This is a test string for zlib compression, hopefully it gets smaller.";
+        println!("Original data: '{}'", original_data);
+        println!("Original length: {}", original_data.len());
+
+        match compress_rust_string(original_data) {
+            Ok(compressed_data) => {
+                println!("Compressed length: {}", compressed_data.len());
+                // For very short strings, compression might not reduce size.
+                // For a reasonably long string, it should.
+                assert!(compressed_data.len() > 0, "Compressed data should not be empty.");
+                if original_data.len() > 20 { // Only assert smaller if original is somewhat long
+                    assert!(compressed_data.len() < original_data.len(), "Compressed data should be smaller than original for this input.");
+                }
+
+                // To actually verify, we would need a decompress function.
+                // For now, we're just checking that it ran and changed the data size.
+                // Example: print first few bytes of compressed data
+                // println!("Compressed data (first 10 bytes as hex): {:?}", &compressed_data.iter().take(10).map(|&b| format!("{:02x}", b)).collect::<Vec<String>>());
+            }
+            Err(e) => {
+                panic!("test_compression_basic failed: {}", e);
+            }
+        }
+    }
+
+    #[test]
+    fn test_compression_empty_string() {
+        let original_data = "";
+        println!("Original data: '{}'", original_data);
+        println!("Original length: {}", original_data.len());
+
+        match compress_rust_string(original_data) {
+            Ok(compressed_data) => {
+                println!("Compressed length for empty string: {}", compressed_data.len());
+                // zlib compressing an empty string results in a small, fixed-size output
+                assert!(compressed_data.len() > 0, "Compressed empty string should not be empty.");
+            }
+            Err(e) => {
+                panic!("test_compression_empty_string failed: {}", e);
+            }
+        }
+    }
+
+    #[test]
+    fn test_string_with_null_byte_internal() {
+        // CString::new will fail for strings with interior null bytes.
+        let original_data = "hello\0world";
+        // We expect compress_rust_string to return an Err here.
+        assert!(compress_rust_string(original_data).is_err(), "Should fail for string with internal null byte due to CString conversion.");
+    }
+}


### PR DESCRIPTION
This project demonstrates how to call a C library function (from zlib) using Rust FFI.

It includes:
- A simple C function `compress_string` in `src/clib.c` that uses zlib to compress a given string.
- A `build.rs` script that compiles the C code and links against the system's zlib library (using `cc` and `pkg-config` crates).
- Rust FFI bindings in `src/lib.rs` for the C function and related struct.
- A safe Rust wrapper function `compress_rust_string` that handles C string conversion and memory management for the FFI call.
- Unit tests in `src/lib.rs` to verify basic compression functionality and error handling for invalid input strings.
- `Cargo.toml` updated with `libc` dependency and `cc`, `pkg-config` build dependencies.