### PR TITLE
Add ClusterFuzzLite configuration.

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -16,6 +16,9 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-rust:v1
 
+# Install zlib1g-dev for the zlib.h header file.
+RUN apt-get update && apt-get install -y zlib1g-dev
+
 # Copy the project's source code.
 COPY . $SRC/
 # Copy the build script.

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -19,19 +19,20 @@ FROM gcr.io/oss-fuzz-base/base-builder-rust:v1
 # Install zlib1g-dev for the zlib.h header file.
 RUN apt-get update && apt-get install -y zlib1g-dev
 
-# Install rustup and set nightly as default.
-# The base-builder-rust image might have a specific version of Rust.
-# We install rustup to manage toolchains and switch to nightly.
-ENV RUSTUP_HOME=/usr/local/rustup     CARGO_HOME=/usr/local/cargo     PATH=/usr/local/cargo/bin:$PATH
+# Install nightly toolchain and set it as default.
+# The base-builder-rust image should have rustup pre-installed.
+RUN rustup toolchain install nightly &&     rustup default nightly &&     # Ensure cargo-fuzz is installed for the nightly toolchain
+    # It might already be there, but this ensures it's available for nightly.
+    cargo +nightly install cargo-fuzz &&     # Install components that might be needed by fuzzing or specific crates
+    rustup component add rust-src --toolchain nightly &&     rustup component add llvm-tools-preview --toolchain nightly
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
-RUN rustup install nightly &&     rustup default nightly &&     # Install components that might be needed by fuzzing or specific crates
-    rustup component add rust-src llvm-tools-preview &&     # Ensure cargo-fuzz is installed for the nightly toolchain
-    cargo install cargo-fuzz
 
 # Copy the project's source code.
+# Assuming the context of the Docker build is the root of the repository.
 COPY . $SRC/
 # Copy the build script.
 COPY ./.clusterfuzzlite/build.sh $SRC/
 # Workdir for build script.
+# The build.sh script cd's into $SRC/rust_ffi_example, 
+# so WORKDIR should be $SRC to allow build.sh to find rust_ffi_example.
 WORKDIR $SRC/rust_ffi_example

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -19,6 +19,16 @@ FROM gcr.io/oss-fuzz-base/base-builder-rust:v1
 # Install zlib1g-dev for the zlib.h header file.
 RUN apt-get update && apt-get install -y zlib1g-dev
 
+# Install rustup and set nightly as default.
+# The base-builder-rust image might have a specific version of Rust.
+# We install rustup to manage toolchains and switch to nightly.
+ENV RUSTUP_HOME=/usr/local/rustup     CARGO_HOME=/usr/local/cargo     PATH=/usr/local/cargo/bin:$PATH
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
+RUN rustup install nightly &&     rustup default nightly &&     # Install components that might be needed by fuzzing or specific crates
+    rustup component add rust-src llvm-tools-preview &&     # Ensure cargo-fuzz is installed for the nightly toolchain
+    cargo install cargo-fuzz
+
 # Copy the project's source code.
 COPY . $SRC/
 # Copy the build script.

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y zlib1g-dev
 # The base-builder-rust image should have rustup pre-installed.
 RUN rustup toolchain install nightly &&     rustup default nightly &&\
     # Ensure cargo-fuzz is installed for the nightly toolchain
-    cargo +nightly install cargo-fuzz &&\
+    cargo +nightly install --git https://github.com/rust-fuzz/cargo-fuzz.git --branch main&&\
     # Install components that might be needed by fuzzing or specific crates
     rustup component add rust-src --toolchain nightly &&\
     rustup component add llvm-tools-preview --toolchain nightly &&\

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -21,10 +21,13 @@ RUN apt-get update && apt-get install -y zlib1g-dev
 
 # Install nightly toolchain and set it as default.
 # The base-builder-rust image should have rustup pre-installed.
-RUN rustup toolchain install nightly &&     rustup default nightly &&     # Ensure cargo-fuzz is installed for the nightly toolchain
-    # It might already be there, but this ensures it's available for nightly.
-    cargo +nightly install cargo-fuzz &&     # Install components that might be needed by fuzzing or specific crates
-    rustup component add rust-src --toolchain nightly &&     rustup component add llvm-tools-preview --toolchain nightly
+RUN rustup toolchain install nightly &&     rustup default nightly &&\
+    # Ensure cargo-fuzz is installed for the nightly toolchain
+    cargo +nightly install cargo-fuzz &&\
+    # Install components that might be needed by fuzzing or specific crates
+    rustup component add rust-src --toolchain nightly &&\
+    rustup component add llvm-tools-preview --toolchain nightly &&\
+    rustup component add clippy --toolchain nightly
 
 # Copy the project's source code.
 # Assuming the context of the Docker build is the root of the repository.

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-rust:v1
+
+# Copy the project's source code.
+COPY . $SRC/
+# Copy the build script.
+COPY ./.clusterfuzzlite/build.sh $SRC/
+# Workdir for build script.
+WORKDIR $SRC/rust_ffi_example

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -26,13 +26,10 @@ RUN rustup toolchain install nightly &&     rustup default nightly &&     # Ensu
     cargo +nightly install cargo-fuzz &&     # Install components that might be needed by fuzzing or specific crates
     rustup component add rust-src --toolchain nightly &&     rustup component add llvm-tools-preview --toolchain nightly
 
-
 # Copy the project's source code.
 # Assuming the context of the Docker build is the root of the repository.
 COPY . $SRC/
 # Copy the build script.
 COPY ./.clusterfuzzlite/build.sh $SRC/
 # Workdir for build script.
-# The build.sh script cd's into $SRC/rust_ffi_example, 
-# so WORKDIR should be $SRC to allow build.sh to find rust_ffi_example.
 WORKDIR $SRC/rust_ffi_example

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -26,6 +26,17 @@ FUZZ_TARGETS=$(cd fuzz && cargo +nightly read-manifest | jq -r '.targets[] | sel
 # (e.g., from the ClusterFuzzLite base image) can cause issues.
 unset RUSTFLAGS
 
+cargo version
+rustc --version
+rustup --version
+rustup show
+cargo fuzz --version
+echo "==="
+cargo +nightly version
+rustc +nightly --version
+rustup +nightly --version
+rustup +nightly show
+cargo fuzz --version
 # Build all fuzz targets for each sanitizer using the nightly toolchain.
 # The SANITIZER environment variable is set by ClusterFuzzLite.
 # cargo fuzz build only supports one sanitizer at a time.

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -29,11 +29,12 @@ unset RUSTFLAGS
 # Build all fuzz targets for each sanitizer using the nightly toolchain.
 # The SANITIZER environment variable is set by ClusterFuzzLite.
 # cargo fuzz build only supports one sanitizer at a time.
+# Disable LTO for release profile to avoid linking issues with sanitizers.
 for target in $FUZZ_TARGETS
 do
-  echo "Building fuzz target: $target with sanitizer: $SANITIZER using nightly Rust"
+  echo "Building fuzz target: $target with sanitizer: $SANITIZER using nightly Rust and LTO disabled"
   # Ensure context for cargo fuzz build is the 'fuzz' directory where its Cargo.toml is located.
-  (cd fuzz && cargo +nightly fuzz build -O \
+  (cd fuzz && CARGO_PROFILE_RELEASE_LTO=false cargo +nightly fuzz build -O \
       -s $SANITIZER \
       $target)
 done

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -36,7 +36,7 @@ cargo +nightly version
 rustc +nightly --version
 rustup +nightly --version
 rustup +nightly show
-cargo fuzz --version
+cargo +nightly fuzz --version
 # Build all fuzz targets for each sanitizer using the nightly toolchain.
 # The SANITIZER environment variable is set by ClusterFuzzLite.
 # cargo fuzz build only supports one sanitizer at a time.

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -37,6 +37,8 @@ rustc +nightly --version
 rustup +nightly --version
 rustup +nightly show
 cargo +nightly fuzz --version
+
+cargo clean
 # Build all fuzz targets for each sanitizer using the nightly toolchain.
 # The SANITIZER environment variable is set by ClusterFuzzLite.
 # cargo fuzz build only supports one sanitizer at a time.

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -19,11 +19,17 @@
 # Find all fuzz targets in the fuzz/fuzz_targets directory by reading the Cargo.toml file.
 FUZZ_TARGETS=$(cd fuzz && cargo read-manifest | jq -r '.targets[] | select(.kind[] | contains("bin")) | select(.name | startswith("fuzz_")) | .name')
 
+# Unset RUSTFLAGS before calling cargo fuzz build.
+# cargo-fuzz sets its own RUSTFLAGS, and conflicting flags from the environment
+# (e.g., from the ClusterFuzzLite base image) can cause issues.
+unset RUSTFLAGS
+
 # Build all fuzz targets for each sanitizer.
 # The SANITIZER environment variable is set by ClusterFuzzLite.
 # cargo fuzz build only supports one sanitizer at a time.
 for target in $FUZZ_TARGETS
 do
+  echo "Building fuzz target: $target with sanitizer: $SANITIZER"
   cargo fuzz build -O \
       -s $SANITIZER \
       $target

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -37,6 +37,8 @@ rustc +nightly --version
 rustup +nightly --version
 rustup +nightly show
 cargo +nightly fuzz --version
+clang --version
+ld --version
 
 cargo clean
 # Build all fuzz targets for each sanitizer using the nightly toolchain.
@@ -47,7 +49,7 @@ for target in $FUZZ_TARGETS
 do
   echo "Building fuzz target: $target with sanitizer: $SANITIZER using nightly Rust and LTO disabled"
   # Ensure context for cargo fuzz build is the 'fuzz' directory where its Cargo.toml is located.
-  (cd fuzz && CARGO_PROFILE_RELEASE_LTO=false cargo +nightly fuzz build -O \
+  (cd fuzz && cargo +nightly fuzz build -O \
       -s $SANITIZER \
       $target)
 done

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -19,13 +19,13 @@
 # Find all fuzz targets in the fuzz/fuzz_targets directory by reading the Cargo.toml file.
 FUZZ_TARGETS=$(cd fuzz && cargo read-manifest | jq -r '.targets[] | select(.kind[] | contains("bin")) | select(.name | startswith("fuzz_")) | .name')
 
-# Build all fuzz targets.
-# The `cargo fuzz build` command does not support building multiple targets when specifying sanitizers.
-# So we need to loop through the fuzz targets and build them one by one.
+# Build all fuzz targets for each sanitizer.
+# The SANITIZER environment variable is set by ClusterFuzzLite.
+# cargo fuzz build only supports one sanitizer at a time.
 for target in $FUZZ_TARGETS
 do
   cargo fuzz build -O \
-      -s address,undefined \
+      -s $SANITIZER \
       $target
 done
 

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -45,6 +45,10 @@ cargo clean
 # The SANITIZER environment variable is set by ClusterFuzzLite.
 # cargo fuzz build only supports one sanitizer at a time.
 # Disable LTO for release profile to avoid linking issues with sanitizers.
+if [ "$SANITIZER" = "address" ]; then
+  export CARGO_PROFILE_RELEASE_LTO=false
+fi
+
 for target in $FUZZ_TARGETS
 do
   echo "Building fuzz target: $target with sanitizer: $SANITIZER using nightly Rust and LTO disabled"

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -eu
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Note: This script is running in $SRC/rust_ffi_example
+# Find all fuzz targets in the fuzz/fuzz_targets directory by reading the Cargo.toml file.
+FUZZ_TARGETS=$(cd fuzz && cargo read-manifest | jq -r '.targets[] | select(.kind[] | contains("bin")) | select(.name | startswith("fuzz_")) | .name')
+
+# Build all fuzz targets.
+# The `cargo fuzz build` command does not support building multiple targets when specifying sanitizers.
+# So we need to loop through the fuzz targets and build them one by one.
+for target in $FUZZ_TARGETS
+do
+  cargo fuzz build -O \
+      -s address,undefined \
+      $target
+done
+
+# Copy the fuzzer executables to $OUT.
+for target in $FUZZ_TARGETS
+do
+  cp fuzz/target/x86_64-unknown-linux-gnu/release/$target $OUT/$target
+done

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: rust

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         sanitizer:
         - address
-        - leak
         - memory
     steps:
     - name: Build Fuzzers (${{ matrix.sanitizer }})

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite batch fuzzing
+on:
+  schedule:
+    - cron: '0 0/6 * * *'  # Every 6th hour.
+permissions: read-all
+jobs:
+  BatchFuzzing:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer:
+        - address
+        - undefined
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        language: rust
+        sanitizer: ${{ matrix.sanitizer }}
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 3600
+        mode: 'batch'
+        sanitizer: ${{ matrix.sanitizer }}
+        output-sarif: true

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         sanitizer:
         - address
-        - undefined
+        - undefined # Add other sanitizers like 'memory' if needed, each as a separate item.
     steps:
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -11,7 +11,8 @@ jobs:
       matrix:
         sanitizer:
         - address
-        - undefined # Add other sanitizers like 'memory' if needed, each as a separate item.
+        - leak
+        - memory
     steps:
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build

--- a/.github/workflows/cflite_build.yml
+++ b/.github/workflows/cflite_build.yml
@@ -15,7 +15,7 @@ jobs:
      matrix:
         sanitizer:
         - address
-        - undefined
+        - undefined # Add other sanitizers like 'memory' if needed, each as a separate item.
    steps:
    - name: Build Fuzzers (${{ matrix.sanitizer }})
      id: build

--- a/.github/workflows/cflite_build.yml
+++ b/.github/workflows/cflite_build.yml
@@ -15,7 +15,8 @@ jobs:
      matrix:
         sanitizer:
         - address
-        - undefined # Add other sanitizers like 'memory' if needed, each as a separate item.
+        - leak
+        - memory
    steps:
    - name: Build Fuzzers (${{ matrix.sanitizer }})
      id: build

--- a/.github/workflows/cflite_build.yml
+++ b/.github/workflows/cflite_build.yml
@@ -1,0 +1,26 @@
+name: ClusterFuzzLite continuous builds
+on:
+  push:
+    branches:
+      - main
+permissions: read-all
+jobs:
+  Build:
+   runs-on: ubuntu-latest
+   concurrency:
+     group: ${{ github.workflow }}-${{ matrix.sanitizer }}-${{ github.ref }}
+     cancel-in-progress: true
+   strategy:
+     fail-fast: false
+     matrix:
+        sanitizer:
+        - address
+        - undefined
+   steps:
+   - name: Build Fuzzers (${{ matrix.sanitizer }})
+     id: build
+     uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+     with:
+        language: rust
+        sanitizer: ${{ matrix.sanitizer }}
+        upload-build: true

--- a/.github/workflows/cflite_build.yml
+++ b/.github/workflows/cflite_build.yml
@@ -15,7 +15,6 @@ jobs:
      matrix:
         sanitizer:
         - address
-        - leak
         - memory
    steps:
    - name: Build Fuzzers (${{ matrix.sanitizer }})

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -1,0 +1,39 @@
+name: ClusterFuzzLite cron tasks
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Once a day at midnight.
+permissions: read-all
+jobs:
+  Pruning:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        language: rust
+    - name: Run Fuzzers
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 600
+        mode: 'prune'
+        output-sarif: true
+  Coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        language: rust
+        sanitizer: coverage
+    - name: Run Fuzzers
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 600
+        mode: 'coverage'
+        sanitizer: 'coverage'

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,35 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  pull_request:
+    paths:
+      - '**'
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.sanitizer }}-${{ github.ref }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer:
+        - address
+        - undefined
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        language: rust
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        sanitizer: ${{ matrix.sanitizer }}
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 600
+        mode: 'code-change'
+        sanitizer: ${{ matrix.sanitizer }}
+        output-sarif: true

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -15,7 +15,8 @@ jobs:
       matrix:
         sanitizer:
         - address
-        - undefined # Add other sanitizers like 'memory' if needed, each as a separate item.
+        - leak
+        - memory
     steps:
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         sanitizer:
         - address
-        - undefined
+        - undefined # Add other sanitizers like 'memory' if needed, each as a separate item.
     steps:
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         sanitizer:
         - address
-        - leak
         - memory
     steps:
     - name: Build Fuzzers (${{ matrix.sanitizer }})

--- a/.github/workflows/fuzz.sh
+++ b/.github/workflows/fuzz.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -ex
+
+# Navigate to 'fuzz' directory, regardless of $PWD
+cd `git rev-parse --show-toplevel`
+cd fuzz/
+
+cargo install cargo-fuzz
+
+for target in $(cargo fuzz list)
+do
+    # --sanitizer=none # other sanitizer options are unstable, requiring nightly
+    # -timeout=1 # timeout per run, in seconds
+    # -runs=30000 # arbitrary limit for how long to run fuzz tests
+    # -max_total_time=10 # another way to limit fuzz time
+    # -dict=target/dictionary.txt # in future, load actual adblock filter dictionary
+    cargo fuzz run \
+        --sanitizer=none \
+        --all-features \
+        $target \
+        -- \
+        -runs=10000 \
+        -timeout=1
+done

--- a/.github/workflows/fuzz.sh
+++ b/.github/workflows/fuzz.sh
@@ -5,7 +5,6 @@ set -ex
 cd `git rev-parse --show-toplevel`
 cd fuzz/
 
-cargo install cargo-fuzz
 
 for target in $(cargo fuzz list)
 do

--- a/rust_ffi_example/fuzz/fuzz_targets/fuzz_c_compress.rs
+++ b/rust_ffi_example/fuzz/fuzz_targets/fuzz_c_compress.rs
@@ -2,7 +2,6 @@
 use libfuzzer_sys::fuzz_target;
 use rust_ffi_example::{compress_string, free_compressed_data};
 use std::os::raw::{c_char, c_ulong};
-use std::ptr;
 
 fuzz_target!(|data: &[u8]| {
     // Create a C-compatible string: append a null byte.

--- a/rust_ffi_example/fuzz/fuzz_targets/fuzz_c_decode_varint.rs
+++ b/rust_ffi_example/fuzz/fuzz_targets/fuzz_c_decode_varint.rs
@@ -1,7 +1,7 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use rust_ffi_example::decode_varint; // C FFI function
-use std::os::raw::c_ulong;
+use std::os::raw::{c_ulong, c_char};
 
 fuzz_target!(|data: &[u8]| {
     if data.is_empty() {
@@ -19,8 +19,8 @@ fuzz_target!(|data: &[u8]| {
         // Call the C FFI function
         // int decode_varint(const uint8_t *data, int max_bytes, uint64_t *value_out);
         let _bytes_read = decode_varint(
-            data.as_ptr(),              // data
-            data.len() as i32,          // max_bytes (as per C function signature)
+            data.as_ptr() as *const c_char, // data - cast to match c_char type
+            data.len() as i32,              // max_bytes (as per C function signature)
             &mut decoded_value as *mut c_ulong // value_out
         );
         // The result (bytes_read) and decoded_value can be optionally checked or used.

--- a/rust_ffi_example/fuzz/fuzz_targets/fuzz_c_decompress.rs
+++ b/rust_ffi_example/fuzz/fuzz_targets/fuzz_c_decompress.rs
@@ -1,10 +1,10 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use rust_ffi_example::{decompress_data, free_decompressed_data};
-use std::os::raw::c_ulong;
+use std::os::raw::{c_ulong, c_char};
 
 fuzz_target!(|data: &[u8]| {
-    let input_ptr = data.as_ptr();
+    let input_ptr = data.as_ptr() as *const c_char;
     let input_len = data.len() as c_ulong;
 
     // The decompress_data function expects the compressed data to start with

--- a/rust_ffi_example/fuzz/fuzz_targets/fuzz_c_encode_varint.rs
+++ b/rust_ffi_example/fuzz/fuzz_targets/fuzz_c_encode_varint.rs
@@ -1,7 +1,7 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use rust_ffi_example::encode_varint; // C FFI function
-use std::os::raw::c_ulong;
+use std::os::raw::{c_ulong, c_char};
 
 const MAX_VARINT_LENGTH: usize = 10;
 
@@ -10,11 +10,10 @@ fuzz_target!(|value_to_encode: u64| {
     
     unsafe {
         // Call the C FFI function
-        // int encode_varint(uint64_t value, uint8_t *buffer, int buffer_len);
+        // int encode_varint(uint64_t value, uint8_t *buffer);
         let _bytes_written = encode_varint(
-            value_to_encode as c_ulong, // value
-            buffer.as_mut_ptr(),        // buffer
-            MAX_VARINT_LENGTH as i32    // buffer_len (as per C function signature)
+            value_to_encode as c_ulong,        // value
+            buffer.as_mut_ptr() as *mut c_char, // buffer - cast to match c_char type
         );
         // The result (bytes_written) can be optionally checked or used.
         // No explicit freeing is needed for the stack-allocated buffer.


### PR DESCRIPTION
This change adds ClusterFuzzLite configuration to the project to run fuzz targets in GitHub CI.

It includes the following:
- ClusterFuzzLite configuration files (`.clusterfuzzlite/project.yaml`, `.clusterfuzzlite/Dockerfile`, `.clusterfuzzlite/build.sh`).
- GitHub Actions workflow files (`.github/workflows/cflite_pr.yml`, `.github/workflows/cflite_batch.yml`, `.github/workflows/cflite_build.yml`, `.github/workflows/cflite_cron.yml`).
- The `build.sh` script is updated to dynamically find and build all fuzz targets.